### PR TITLE
Set correct codepage for `cp437`-encoded text at the beginning of the command

### DIFF
--- a/src/receipt-printer-encoder.js
+++ b/src/receipt-printer-encoder.js
@@ -196,7 +196,7 @@ class ReceiptPrinterEncoder {
   #reset() {
     this.#queue = [];
     this.#codepage = this.#options.language == 'esc-pos' ? 'cp437' : 'star/standard';
-    this.#state.codepage = 0;
+    this.#state.codepage = -1;
     this.#state.font = 'A';
   }
 


### PR DESCRIPTION
Fixes #48

How to validate changes:

```javascript
const cmd = new ReceiptPrinterEncoder()
  .initialize()
  .codepage('cp437')
  .text('╔')
  .encode('lines')

console.log(cmd)
```

#### Before

```
[
  [
    { type: 'initialize', payload: [Array] },
    { type: 'character-mode', value: 'single byte', payload: [Array] },
    { type: 'font', value: 'A', payload: [Array] },
    { type: 'text', payload: [Array] }
  ]
]
```

#### After

`codepage` command is inserted right before `text` command

```
[
  [
    { type: 'initialize', payload: [Array] },
    { type: 'character-mode', value: 'single byte', payload: [Array] },
    { type: 'font', value: 'A', payload: [Array] },
    { type: 'codepage', payload: [Array] },
    { type: 'text', payload: [Array] }
  ]
]
```